### PR TITLE
Update caravan role

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,2 +1,3 @@
 openprocurement.contracting.core
 ===============================
+

--- a/openprocurement/contracting/core/tests/traversal.py
+++ b/openprocurement/contracting/core/tests/traversal.py
@@ -33,6 +33,8 @@ class TraversalTest(BaseWebTest):
         (Allow, Everyone, 'view_listing'),
         (Allow, Everyone, 'view_contract'),
         (Allow, 'g:contracting', 'create_contract'),
+        (Allow, 'g:caravan', 'view_contract'),
+        (Allow, 'g:caravan', 'edit_contract'),
         (Allow, 'g:brokers', 'create_contract'),
         (Allow, 'g:convoy', 'create_contract'),
         (Allow, 'g:Administrator', 'edit_contract'),

--- a/openprocurement/contracting/core/traversal.py
+++ b/openprocurement/contracting/core/traversal.py
@@ -15,6 +15,8 @@ class Root(object):
         (Allow, Everyone, 'view_listing'),
         (Allow, Everyone, 'view_contract'),
         (Allow, 'g:contracting', 'create_contract'),
+        (Allow, 'g:caravan', 'view_contract'),
+        (Allow, 'g:caravan', 'edit_contract'),
         (Allow, 'g:brokers', 'create_contract'),
         (Allow, 'g:convoy', 'create_contract'),
         (Allow, 'g:Administrator', 'edit_contract'),


### PR DESCRIPTION
Caravan doesn't create contract in it's normal flow, so it mustn't have `create_contract` permission. I gave it `view_contract` and `edit_contract` instead.